### PR TITLE
Refactor: Move reading database functions to db directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,7 +49,7 @@
   - Dependencies: None
   - Priority: High
 
-- [ ] Move reading utilities
+- [x] Move reading utilities
   - Description: Move database access functions from src/app/readings/utils.ts to src/lib/db/readings.ts
   - Dependencies: src/lib/db directory
   - Priority: High

--- a/src/app/readings/[slug]/page.tsx
+++ b/src/app/readings/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { Reading } from '../page'
-import { getReading } from '../utils'
+import { getReading } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'; // Disable static rendering and caching
 

--- a/src/app/readings/__tests__/detail.test.tsx
+++ b/src/app/readings/__tests__/detail.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { getReading } from '../utils';
+import { getReading } from '@/lib/db';
 import ReadingDetailPage from '../[slug]/page';
 import prisma from '@/lib/prisma';
 

--- a/src/app/readings/__tests__/page.test.tsx
+++ b/src/app/readings/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { getReadings } from '../utils';
+import { getReadings } from '@/lib/db';
 import ReadingsPage from '../page';
 import prisma from '@/lib/prisma';
 

--- a/src/app/readings/page.tsx
+++ b/src/app/readings/page.tsx
@@ -1,5 +1,5 @@
 import ReadingCard from '../components/ReadingCard'
-import { getReadings } from './utils'
+import { getReadings } from '@/lib/db'
 
 export type Reading = {
   id: number

--- a/src/app/readings/utils.ts
+++ b/src/app/readings/utils.ts
@@ -1,50 +1,11 @@
-import prisma from '@/lib/prisma'
+/**
+ * @deprecated This file is deprecated and will be removed in a future version.
+ * Please import from '@/lib/db' instead.
+ * 
+ * Example:
+ * import { getReading, getReadings } from '@/lib/db'
+ */
 
-export async function getReading(slug: string) {
-  try {
-    console.log(`Fetching reading with slug: ${slug}`)
-    
-    // Use raw query for maximum compatibility
-    const readings = await prisma.$queryRaw`
-      SELECT id, slug, title, author, "finishedDate", "coverImageSrc", thoughts, dropped
-      FROM "Reading"
-      WHERE slug = ${slug}
-      LIMIT 1;
-    `
-    
-    const reading = Array.isArray(readings) && readings.length > 0 ? readings[0] : null
-    
-    console.log(reading ? `Found reading: ${reading.title}` : `No reading found for slug: ${slug}`)
-    return reading
-  } catch (error) {
-    console.error(`Error fetching reading with slug ${slug}:`, error)
-    return null
-  }
-}
+import { getReading, getReadings } from '@/lib/db'
 
-export async function getReadings() {
-  try {
-    console.log('Getting readings from database...')
-    
-    // Use raw query for maximum compatibility
-    const readings = await prisma.$queryRaw`
-      SELECT id, slug, title, author, "finishedDate", "coverImageSrc", thoughts, dropped
-      FROM "Reading"
-      ORDER BY 
-        CASE WHEN "finishedDate" IS NULL THEN 1 ELSE 0 END,
-        "finishedDate" DESC,
-        id DESC;
-    `
-    
-    console.log(`Found ${Array.isArray(readings) ? readings.length : 0} readings`)
-    
-    if (!readings || (Array.isArray(readings) && readings.length === 0)) {
-      console.warn('No readings found in database')
-    }
-    
-    return readings
-  } catch (error) {
-    console.error('Error fetching readings:', error)
-    return []
-  }
-}
+export { getReading, getReadings }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -5,12 +5,16 @@
  * Database operations are organized by entity (readings, quotes, etc.) for improved maintainability.
  */
 
-// Import entity-specific database utilities when they're created
-// import * as readingsDb from './readings';
+// Import entity-specific database utilities
+import * as readingsDb from './readings';
 // import * as quotesDb from './quotes';
 
 // Re-export all database utilities
-// export { readingsDb, quotesDb };
+export { readingsDb };
+// export { quotesDb };
+
+// Export individual reading functions for backward compatibility
+export const { getReading, getReadings } = readingsDb;
 
 // Export the Prisma client
 export { default as prisma } from '../prisma';

--- a/src/lib/db/readings.ts
+++ b/src/lib/db/readings.ts
@@ -2,14 +2,66 @@
  * Readings database utility functions
  * 
  * Contains all database operations related to the Reading entity.
- * These functions will be moved from src/app/readings/utils.ts in a subsequent task.
  */
 
 import prisma from '../prisma';
 
-// This file will contain functions like:
-// - getReadings
-// - getReading
-// - createReading
-// - updateReading
-// - deleteReading
+/**
+ * Fetches a single reading by slug
+ * 
+ * @param slug - The unique slug identifier of the reading
+ * @returns The reading object or null if not found
+ */
+export async function getReading(slug: string) {
+  try {
+    console.log(`Fetching reading with slug: ${slug}`)
+    
+    // Use raw query for maximum compatibility
+    const readings = await prisma.$queryRaw`
+      SELECT id, slug, title, author, "finishedDate", "coverImageSrc", thoughts, dropped
+      FROM "Reading"
+      WHERE slug = ${slug}
+      LIMIT 1;
+    `
+    
+    const reading = Array.isArray(readings) && readings.length > 0 ? readings[0] : null
+    
+    console.log(reading ? `Found reading: ${reading.title}` : `No reading found for slug: ${slug}`)
+    return reading
+  } catch (error) {
+    console.error(`Error fetching reading with slug ${slug}:`, error)
+    return null
+  }
+}
+
+/**
+ * Fetches all readings from the database
+ * 
+ * @returns Array of reading objects ordered by finished date (desc)
+ */
+export async function getReadings() {
+  try {
+    console.log('Getting readings from database...')
+    
+    // Use raw query for maximum compatibility
+    const readings = await prisma.$queryRaw`
+      SELECT id, slug, title, author, "finishedDate", "coverImageSrc", thoughts, dropped
+      FROM "Reading"
+      ORDER BY 
+        CASE WHEN "finishedDate" IS NULL THEN 1 ELSE 0 END,
+        "finishedDate" DESC,
+        id DESC;
+    `
+    
+    console.log(`Found ${Array.isArray(readings) ? readings.length : 0} readings`)
+    
+    if (!readings || (Array.isArray(readings) && readings.length === 0)) {
+      console.warn('No readings found in database')
+    }
+    
+    return readings
+  } catch (error) {
+    console.error('Error fetching readings:', error)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- Move getReading and getReadings from app/readings/utils.ts to lib/db/readings.ts
- Update imports in all affected files
- Keep utils.ts temporarily with re-exports for backward compatibility
- Export functions from lib/db/index.ts
- Add JSDoc comments to functions

## Test plan
- Ran all tests to verify they still pass
- Verified build still works
- Checked that all files reference the new import paths

This PR completes the 'Move reading utilities' task from TODO.md.