### PR TITLE
Curate project showcase: add active repos, remove stale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .polish-sessions
 .design-catalogue/
 experiments/
+.claude/launch.json

--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
         </a>
 
         <div class="projects-grid">
+          <a href="https://github.com/misty-step/cerberus" target="_blank" rel="noopener" class="project reveal">
+            <h4>cerberus</h4>
+            <p>Multi-agent AI code review council. Five parallel agents gate every PR.</p>
+          </a>
           <a href="https://www.heartbeat.engineering/" target="_blank" rel="noopener" class="project reveal">
             <h4>heartbeat</h4>
             <p>Set-and-forget uptime monitoring. Beautiful status pages.</p>
@@ -66,21 +70,45 @@
             <h4>gitpulse</h4>
             <p>GitHub analytics with AI summaries. Every claim cited.</p>
           </a>
+          <a href="https://github.com/phrazzld/agent-skills" target="_blank" rel="noopener" class="project reveal">
+            <h4>agent-skills</h4>
+            <p>Portable skill library for AI coding agents. Debugging, PR workflows, design systems.</p>
+          </a>
+          <a href="https://github.com/misty-step/thinktank" target="_blank" rel="noopener" class="project reveal">
+            <h4>thinktank</h4>
+            <p>Multi-model code review. GPT, Claude, Gemini in one CLI.</p>
+          </a>
+          <a href="https://github.com/misty-step/vox" target="_blank" rel="noopener" class="project reveal">
+            <h4>vox</h4>
+            <p>Invisible macOS editor. Hotkey dictation to clean text.</p>
+          </a>
           <a href="https://www.scry.study/" target="_blank" rel="noopener" class="project reveal">
             <h4>scry</h4>
             <p>Paste anything, get flashcards. Spaced repetition.</p>
           </a>
-          <a href="https://www.chrondle.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>chrondle</h4>
-            <p>The history nerd's Wordle. Six events, one year.</p>
-          </a>
-          <a href="https://brainrot-publishing-house.vercel.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>brainrot publishing house</h4>
-            <p>Gen Z translations of classic literature. No cap.</p>
-          </a>
           <a href="https://www.volume.fitness/" target="_blank" rel="noopener" class="project reveal">
             <h4>volume</h4>
             <p>Workout tracking without the cruft.</p>
+          </a>
+          <a href="https://github.com/phrazzld/whetstone" target="_blank" rel="noopener" class="project reveal">
+            <h4>whetstone</h4>
+            <p>Mobile app for tracking your reading.</p>
+          </a>
+          <a href="https://timeismoney-splash.vercel.app/" target="_blank" rel="noopener" class="project reveal">
+            <h4>time is money</h4>
+            <p>Chrome extension that converts prices into hours of work.</p>
+          </a>
+          <a href="https://github.com/phrazzld/glance" target="_blank" rel="noopener" class="project reveal">
+            <h4>glance</h4>
+            <p>CLI that auto-generates directory summaries.</p>
+          </a>
+          <a href="https://github.com/misty-step/sploot" target="_blank" rel="noopener" class="project reveal">
+            <h4>sploot</h4>
+            <p>Browser extension for effortless tab management.</p>
+          </a>
+          <a href="https://www.chrondle.app/" target="_blank" rel="noopener" class="project reveal">
+            <h4>chrondle</h4>
+            <p>The history nerd's Wordle. Six events, one year.</p>
           </a>
           <a href="https://www.caesarinayear.com/" target="_blank" rel="noopener" class="project reveal">
             <h4>caesar in a year</h4>
@@ -90,41 +118,17 @@
             <h4>bibliomnomnom</h4>
             <p>Private-first book tracking. No algorithms.</p>
           </a>
-          <a href="https://linejam.vercel.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>linejam</h4>
-            <p>Pass-the-poem party game for friends.</p>
-          </a>
-          <a href="https://github.com/misty-step/sploot" target="_blank" rel="noopener" class="project reveal">
-            <h4>sploot</h4>
-            <p>Browser extension for effortless tab management.</p>
-          </a>
-          <a href="https://github.com/phrazzld/thinktank" target="_blank" rel="noopener" class="project reveal">
-            <h4>thinktank</h4>
-            <p>Multi-model code review. GPT, Claude, Gemini in one CLI.</p>
+          <a href="https://trump-goggles-splash.vercel.app/" target="_blank" rel="noopener" class="project reveal">
+            <h4>trump goggles</h4>
+            <p>Chrome extension that Trumpifies any webpage.</p>
           </a>
           <a href="https://vibe-machine-eight.vercel.app/" target="_blank" rel="noopener" class="project reveal">
             <h4>vibe machine</h4>
             <p>Audio-reactive visuals. Drop a track, zone out.</p>
           </a>
-          <a href="https://timeismoney-splash.vercel.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>time is money</h4>
-            <p>Chrome extension that converts prices into hours of work.</p>
-          </a>
-          <a href="https://trump-goggles-splash.vercel.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>trump goggles</h4>
-            <p>Chrome extension that Trumpifies any webpage.</p>
-          </a>
-          <a href="https://github.com/phrazzld/glance" target="_blank" rel="noopener" class="project reveal">
-            <h4>glance</h4>
-            <p>CLI that auto-generates directory summaries.</p>
-          </a>
-          <a href="https://github.com/phrazzld/handoff" target="_blank" rel="noopener" class="project reveal">
-            <h4>handoff</h4>
-            <p>Full codebase context copied to clipboard.</p>
-          </a>
-          <a href="https://wrap-it-up.vercel.app/" target="_blank" rel="noopener" class="project reveal">
-            <h4>wrap it up</h4>
-            <p>Simple Christmas-time platformer game.</p>
+          <a href="https://linejam.vercel.app/" target="_blank" rel="noopener" class="project reveal">
+            <h4>linejam</h4>
+            <p>Pass-the-poem party game for friends.</p>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Added** 4 actively developed projects: cerberus (multi-agent code review), agent-skills (AI agent skill library, 4 stars), vox (macOS dictation), whetstone (reading tracker, 3 stars)
- **Removed** 3 stale/archived projects: brainrot publishing house (repo archived), handoff (stale utility), wrap it up (seasonal, last pushed Dec 2025)
- **Fixed** thinktank link to canonical `misty-step/thinktank` repo
- **Reordered** grid to lead with AI/dev tools and live apps, fun projects at bottom

## Test plan
- [ ] Verify all 18 project links resolve correctly
- [ ] Check layout renders properly on desktop and mobile
- [ ] Confirm no removed projects appear in the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the project catalog with newly added projects: cerberus, agent-skills, thinktank, vox, whetstone, and glance. The portfolio now features a refreshed selection of highlighted projects with revised details. Several older project entries have been removed.

* **Chores**
  * Updated repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->