### PR TITLE
feat(observability): integrate Vanity with Canary

### DIFF
--- a/api/canary-config.js
+++ b/api/canary-config.js
@@ -1,0 +1,30 @@
+function withoutTrailingSlash(value) {
+  return String(value || "").replace(/\/+$/, "");
+}
+
+function configuredValue(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+module.exports = function handler(_request, response) {
+  response.setHeader("Cache-Control", "no-store");
+
+  const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
+  const serverKey = configuredValue(process.env.CANARY_API_KEY);
+  const safeBrowserKey = browserKey && browserKey !== serverKey ? browserKey : null;
+
+  response.status(200).json({
+    service: "vanity",
+    environment:
+      process.env.PUBLIC_CANARY_ENVIRONMENT ||
+      process.env.VERCEL_ENV ||
+      "production",
+    endpoint: withoutTrailingSlash(
+      process.env.PUBLIC_CANARY_ENDPOINT ||
+        process.env.CANARY_ENDPOINT ||
+        "https://canary-obs.fly.dev",
+    ),
+    apiKey: safeBrowserKey,
+  });
+};

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,26 @@
+function configuredValue(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+module.exports = function handler(_request, response) {
+  const serverKey = configuredValue(process.env.CANARY_API_KEY);
+  const browserKey = configuredValue(process.env.PUBLIC_CANARY_API_KEY);
+  const serverConfigured = serverKey !== null;
+  const browserConfigured = browserKey !== null;
+  const distinctBrowserKey =
+    browserConfigured && browserKey !== serverKey;
+  const ok = serverConfigured && distinctBrowserKey;
+
+  response.setHeader("Cache-Control", "no-store");
+  response.status(200).json({
+    status: ok ? "ok" : "degraded",
+    service: "vanity",
+    checks: {
+      canary: ok ? "configured" : "missing",
+      canaryServer: serverConfigured ? "configured" : "missing",
+      canaryBrowser: distinctBrowserKey ? "configured" : "missing",
+    },
+    timestamp: new Date().toISOString(),
+  });
+};

--- a/canary-observer.js
+++ b/canary-observer.js
@@ -1,0 +1,145 @@
+(function canaryObserver(root, factory) {
+  const api = factory();
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+    return;
+  }
+
+  root.VanityCanary = api;
+  api.installCanaryObserver();
+})(typeof globalThis !== "undefined" ? globalThis : this, () => {
+  const DEFAULT_CONFIG_PATH = "/api/canary-config";
+  const OBSERVER_VERSION = "vanity-static-v1";
+
+  const REDACTION_RULES = [
+    [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]"],
+    [/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/g, "Bearer [redacted-token]"],
+    [/\bsk_(?:live|test)_[A-Za-z0-9_]+\b/g, "[redacted-key]"],
+    [
+      /https?:\/\/[^\s"'<>?]+(?:\?[^'"<>\s]*)/g,
+      (match) => match.replace(/\?.*$/, "?[redacted-query]"),
+    ],
+    [
+      /(^|[\s"'(])([/?#][^\s"'<>]*\?[^'"<>\s]*)/g,
+      (_match, prefix, path) => `${prefix}${path.replace(/\?.*$/, "?[redacted-query]")}`,
+    ],
+    [/\b[A-Za-z0-9_-]{32,}\b/g, "[redacted-token]"],
+  ];
+
+  function asText(value) {
+    if (value instanceof Error) return value.message || value.name;
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  function redact(value) {
+    return REDACTION_RULES.reduce(
+      (text, [pattern, replacement]) => text.replace(pattern, replacement),
+      asText(value),
+    );
+  }
+
+  function normalizeError(input) {
+    const reason = input?.error || input?.reason;
+    const sourceError =
+      reason instanceof Error ? reason : input instanceof Error ? input : null;
+    const messageSource = reason || input?.message || input;
+    const message = redact(asText(messageSource) || "Unhandled browser error");
+    const name = sourceError ? sourceError.name || "Error" : "Error";
+    const stack = sourceError?.stack ? redact(sourceError.stack) : undefined;
+
+    return { name, message, stack };
+  }
+
+  function createPayload(config, input, page) {
+    const error = normalizeError(input);
+    const location = page?.location?.href || "";
+    const userAgent = page?.navigator?.userAgent || "";
+
+    return {
+      service: config.service || "vanity",
+      environment: config.environment || "production",
+      severity: "error",
+      error_class: error.name,
+      message: error.message,
+      stack: error.stack,
+      source: "browser",
+      context: {
+        observer: OBSERVER_VERSION,
+        page_url: redact(location),
+        user_agent: redact(userAgent),
+      },
+    };
+  }
+
+  async function loadConfig(fetchImpl = fetch, configPath = DEFAULT_CONFIG_PATH) {
+    const response = await fetchImpl(configPath, {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    if (!response.ok) return null;
+
+    const config = await response.json();
+    if (!config?.apiKey || !config?.endpoint) return null;
+
+    return {
+      service: config.service || "vanity",
+      environment: config.environment || "production",
+      endpoint: String(config.endpoint).replace(/\/+$/, ""),
+      apiKey: config.apiKey,
+    };
+  }
+
+  async function reportToCanary(config, payload, fetchImpl = fetch) {
+    if (!config?.apiKey || !config?.endpoint) return false;
+    const endpoint = String(config.endpoint).replace(/\/+$/, "");
+
+    const response = await fetchImpl(`${endpoint}/api/v1/errors`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+
+    return response.ok;
+  }
+
+  async function installCanaryObserver(options = {}) {
+    const page = options.window || window;
+    if (page.__vanityCanaryObserverInstalled) return false;
+    page.__vanityCanaryObserverInstalled = true;
+
+    const fetchImpl = options.fetch || page.fetch.bind(page);
+    const configPromise = options.configPromise || loadConfig(fetchImpl);
+
+    const capture = async (event) => {
+      try {
+        const config = await configPromise;
+        if (!config) return;
+        await reportToCanary(config, createPayload(config, event, page), fetchImpl);
+      } catch {
+        // Observability must never break the page it observes.
+      }
+    };
+
+    page.addEventListener("error", capture);
+    page.addEventListener("unhandledrejection", capture);
+    return true;
+  }
+
+  return {
+    createPayload,
+    installCanaryObserver,
+    loadConfig,
+    redact,
+    reportToCanary,
+  };
+});

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.2.1/aesthetic.css">
+  <script src="/canary-observer.js"></script>
   <style>
     /* site glue: the name row carries the mode toggle */
     .name-row {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,144 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const configHandler = require("../api/canary-config");
+const healthHandler = require("../api/health");
+
+function withEnv(env, fn) {
+  const previous = { ...process.env };
+  process.env = { ...previous, ...env };
+  try {
+    return fn();
+  } finally {
+    process.env = previous;
+  }
+}
+
+function run(handler) {
+  const headers = {};
+  const response = {
+    statusCode: undefined,
+    body: undefined,
+    setHeader(name, value) {
+      headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  handler({}, response);
+  return { headers, statusCode: response.statusCode, body: response.body };
+}
+
+test("health reports ok only when both Canary keys are configured", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "server-key",
+      PUBLIC_CANARY_API_KEY: "browser-key",
+    },
+    () => {
+      const result = run(healthHandler);
+
+      assert.equal(result.statusCode, 200);
+      assert.equal(result.headers["Cache-Control"], "no-store");
+      assert.equal(result.body.status, "ok");
+      assert.equal(result.body.checks.canaryServer, "configured");
+      assert.equal(result.body.checks.canaryBrowser, "configured");
+    },
+  );
+});
+
+test("health reports degraded without a browser ingest key", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "server-key",
+      PUBLIC_CANARY_API_KEY: "",
+    },
+    () => {
+      const result = run(healthHandler);
+
+      assert.equal(result.statusCode, 200);
+      assert.equal(result.body.status, "degraded");
+      assert.equal(result.body.checks.canary, "missing");
+      assert.equal(result.body.checks.canaryServer, "configured");
+      assert.equal(result.body.checks.canaryBrowser, "missing");
+    },
+  );
+});
+
+test("health and config treat whitespace-only browser keys as missing", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "server-key",
+      PUBLIC_CANARY_API_KEY: "   ",
+    },
+    () => {
+      const health = run(healthHandler);
+      const config = run(configHandler);
+
+      assert.equal(health.body.status, "degraded");
+      assert.equal(health.body.checks.canaryBrowser, "missing");
+      assert.equal(config.body.apiKey, null);
+    },
+  );
+});
+
+test("health treats whitespace-only server keys as missing", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "   ",
+      PUBLIC_CANARY_API_KEY: "browser-key",
+    },
+    () => {
+      const health = run(healthHandler);
+
+      assert.equal(health.body.status, "degraded");
+      assert.equal(health.body.checks.canaryServer, "missing");
+      assert.equal(health.body.checks.canaryBrowser, "configured");
+    },
+  );
+});
+
+test("config exposes only the browser Canary key", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "private-server-key",
+      CANARY_ENDPOINT: "https://canary.example.test/",
+      PUBLIC_CANARY_API_KEY: "public-browser-key",
+      PUBLIC_CANARY_ENVIRONMENT: "preview",
+    },
+    () => {
+      const result = run(configHandler);
+
+      assert.equal(result.statusCode, 200);
+      assert.equal(result.headers["Cache-Control"], "no-store");
+      assert.deepEqual(result.body, {
+        service: "vanity",
+        environment: "preview",
+        endpoint: "https://canary.example.test",
+        apiKey: "public-browser-key",
+      });
+      assert.equal(JSON.stringify(result.body).includes("private-server-key"), false);
+    },
+  );
+});
+
+test("config refuses to expose a browser key that matches the server key", () => {
+  withEnv(
+    {
+      CANARY_API_KEY: "same-key",
+      PUBLIC_CANARY_API_KEY: "same-key",
+    },
+    () => {
+      const result = run(configHandler);
+
+      assert.equal(result.body.apiKey, null);
+    },
+  );
+});

--- a/test/canary-observer.test.js
+++ b/test/canary-observer.test.js
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createPayload,
+  installCanaryObserver,
+  loadConfig,
+  redact,
+  reportToCanary,
+} = require("../canary-observer");
+
+test("redact strips common credentials and query strings", () => {
+  const input = [
+    "email phaedrus@example.com",
+    "Bearer abc.def.ghi",
+    ["sk", "live", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_"),
+    "https://example.test/path?token=secret",
+    "/local/path?api_key=secret",
+    "abcdefghijklmnopqrstuvwxyz1234567890ABCDEF",
+  ].join(" ");
+
+  const output = redact(input);
+
+  assert.equal(output.includes("phaedrus@example.com"), false);
+  assert.equal(output.includes("abc.def.ghi"), false);
+  assert.equal(output.includes("secret"), false);
+  assert.equal(output.includes("abcdefghijklmnopqrstuvwxyz1234567890"), false);
+  assert.match(output, /\[redacted-email\]/);
+  assert.match(output, /\[redacted-key\]/);
+  assert.match(output, /\[redacted-query\]/);
+});
+
+test("createPayload keeps the vanity service contract and scrubs page context", () => {
+  const payload = createPayload(
+    { service: "vanity", environment: "production" },
+    { error: new Error("boom for user@example.com") },
+    {
+      location: { href: "https://www.phaedrus.io/?token=secret" },
+      navigator: { userAgent: "test-agent" },
+    },
+  );
+
+  assert.equal(payload.service, "vanity");
+  assert.equal(payload.environment, "production");
+  assert.equal(payload.error_class, "Error");
+  assert.equal(payload.message, "boom for [redacted-email]");
+  assert.equal(payload.context.page_url, "https://www.phaedrus.io/?[redacted-query]");
+});
+
+test("createPayload preserves ErrorEvent messages when error is absent", () => {
+  const payload = createPayload(
+    { service: "vanity", environment: "production" },
+    { message: "script boom" },
+    {
+      location: { href: "https://www.phaedrus.io/" },
+      navigator: { userAgent: "test-agent" },
+    },
+  );
+
+  assert.equal(payload.message, "script boom");
+  assert.equal(payload.error_class, "Error");
+});
+
+test("loadConfig ignores missing browser keys", async () => {
+  const result = await loadConfig(async () => ({
+    ok: true,
+    async json() {
+      return { endpoint: "https://canary.example.test", apiKey: "" };
+    },
+  }));
+
+  assert.equal(result, null);
+});
+
+test("reportToCanary posts to the errors endpoint", async () => {
+  const calls = [];
+  const ok = await reportToCanary(
+    { endpoint: "https://canary.example.test/", apiKey: "public-key" },
+    { service: "vanity", message: "hello" },
+    async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true };
+    },
+  );
+
+  assert.equal(ok, true);
+  assert.equal(calls[0].url, "https://canary.example.test/api/v1/errors");
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.headers.Authorization, "Bearer public-key");
+});
+
+test("installCanaryObserver captures browser errors once", async () => {
+  const listeners = new Map();
+  const calls = [];
+  const page = {
+    location: { href: "https://www.phaedrus.io/" },
+    navigator: { userAgent: "test-agent" },
+    fetch: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true };
+    },
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+  };
+
+  const installed = await installCanaryObserver({
+    window: page,
+    configPromise: Promise.resolve({
+      service: "vanity",
+      environment: "test",
+      endpoint: "https://canary.example.test",
+      apiKey: "public-key",
+    }),
+  });
+  const secondInstall = await installCanaryObserver({ window: page });
+
+  await listeners.get("error")({ error: new Error("vanity smoke") });
+
+  assert.equal(installed, true);
+  assert.equal(secondInstall, false);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://canary.example.test/api/v1/errors");
+});


### PR DESCRIPTION
## Summary
- add Vanity Canary health/config Vercel functions
- install an early browser error observer that reports to Canary service `vanity`
- add Node behavior tests for redaction, config safety, health status, and browser capture

## Verification
- `node --test test/*.test.js`
- `node --check api/canary-config.js`
- `node --check api/health.js`
- `node --check canary-observer.js`
- `git diff --check`
- fresh-context peer critic PASS

## Runtime config
- Vercel production and branch-preview Canary envs installed for `misty-step/vanity`
- keys are service-bound ingest-only keys for `vanity`; raw keys are not included here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error monitoring and reporting system that automatically captures JavaScript errors and sends them to a remote service.
  * Implemented health check endpoint to verify monitoring configuration status.
  * Integrated automatic sensitive data redaction in error reports (emails, tokens, API keys, query parameters).

* **Tests**
  * Added test coverage for API endpoints and error reporting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->