### PR TITLE
ci: add repo-owned gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: repo gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Run repo-owned gate
+        run: ./scripts/check.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,8 @@ Rules for this site:
 ## Deploy
 
 Push to master. Vercel serves the directory statically (`vercel.json`).
+
+## CI
+
+Run `./scripts/check.sh` before claiming done. The GitHub workflow calls the
+same script; change the script first if the gate needs to change.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ imported from the CDN pinned to a release tag.
 
 ```bash
 open index.html        # or any static server
+./scripts/check.sh     # repo-owned CI gate
 ```
 
 ## Conventions
@@ -24,3 +25,8 @@ open index.html        # or any static server
 ## Deploy
 
 Push to master. Vercel serves the directory statically (`vercel.json`).
+
+## CI
+
+`./scripts/check.sh` is the canonical gate. GitHub Actions is a thin caller
+around that script so local and hosted validation stay aligned.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+node --test


### PR DESCRIPTION
## Summary
- add scripts/check.sh as the canonical local gate
- add GitHub Actions as a thin caller around scripts/check.sh
- document the gate in README and CLAUDE.md

## Verification
- ./scripts/check.sh
- sh -n scripts/check.sh
- git diff --check
- actionlint .github/workflows/ci.yml
- thermo-nuclear review: no blockers