### PR TITLE
Fix quote attribution contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     .q-attr {
       margin: 0.6em 0 0;
       font-size: 12px;
-      color: var(--ae-ink-faint);
+      color: var(--ae-ink-muted);
       letter-spacing: 0.06em;
       opacity: 0;
       transition: opacity var(--ae-gentle) var(--ae-ease);


### PR DESCRIPTION
## Goal

Clear Vanity's pre-existing deterministic Allie blocker before landing the DigitalOcean Canary parity change.

## Change

Use Aesthetic's existing `--ae-ink-muted` token for the 12px quote attribution instead of `--ae-ink-faint`.

- light: `#737373` on `#fcfcfc` = 4.62:1
- dark: `#8f8f8f` on `#141414` = 5.70:1

The separate icon-contrast and pause-control findings remain out of scope.

## Proof

- `./scripts/check.sh` — 15/15
- local rendered Allie: exit 0, deterministic failures 0, WCAG failures 0
- previous mainline finding: `#q-attr`, 2.45:1, run 29061145171 / artifact 8215470534

Agent: vanity-parity-implementer
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.4
Agent-Task: vanity-migration-canary
