### PR TITLE
Retire Vanity's Vercel delivery surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ node --test
 
 Direct `file://` opens are acceptable for a quick layout check, but use HTTP
 for delivery QA so root-relative assets such as `/canary-observer.js` load
-normally. `python3 -m http.server` does not emulate Vercel functions; API
-handler behavior is covered by `node --test`, or by a Vercel-shaped local
-server when browser QA must include `/api/*`.
+normally. `python3 -m http.server` does not emulate the DigitalOcean sidecar;
+API handler behavior is covered by `node --test`, or by `service/server.js`
+when browser QA must include `/api/*`.
 
 ## Architecture
 
@@ -43,9 +43,10 @@ server when browser QA must include `/api/*`.
 - `quotes.js` - Generated daybook quote pool consumed by the colophon.
 - `canary-observer.js` - Browser error observer. It must never break the page
   it observes.
-- `api/canary-config.js` - Vercel function that exposes only the public Canary
+- `api/canary-config.js` - portable handler that exposes only the public Canary
   ingest key.
-- `api/health.js` - Vercel health function for Canary key configuration.
+- `api/health.js` - portable health handler for Canary key configuration.
+- `service/server.js` - DigitalOcean sidecar serving both API handlers.
 - `test/*.test.js` - Node test-runner coverage for the API and observer
   contracts.
 
@@ -86,8 +87,9 @@ Rules for this site:
 
 ## Deploy
 
-Push to `master`. Vercel serves the directory statically with the serverless
-API functions declared by `vercel.json`.
+Push to `master`. DigitalOcean serves the static directory and the Node
+sidecar in `service/`; the checked-in App Platform spec is maintained in the
+DigitalOcean migration workspace.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ python3 -m http.server 4173        # or: open index.html
 
 ## Deploy
 
-Push to `master`. Vercel serves the directory statically with the API functions
-declared by `vercel.json`.
+Push to `master`. DigitalOcean serves the static directory and the Node
+sidecar in `service/`.
 
 ## CI
 

--- a/service/canary-contract.js
+++ b/service/canary-contract.js
@@ -13,14 +13,11 @@ function config(environment = process.env) {
 
   return {
     service: "vanity",
-    environment:
-      environment.PUBLIC_CANARY_ENVIRONMENT ||
-      environment.VERCEL_ENV ||
-      "production",
+    environment: environment.PUBLIC_CANARY_ENVIRONMENT || "production",
     endpoint: withoutTrailingSlash(
       environment.PUBLIC_CANARY_ENDPOINT ||
         environment.CANARY_ENDPOINT ||
-        "https://canary-obs.fly.dev",
+        "https://canary.mistystep.io",
     ),
     apiKey: browserKey && browserKey !== serverKey ? browserKey : null,
   };

--- a/test/do-functions.test.js
+++ b/test/do-functions.test.js
@@ -95,6 +95,23 @@ test("DigitalOcean service refuses to publish a server-equivalent browser key", 
   );
 });
 
+test("DigitalOcean defaults ignore retired Vercel environment hints", async () => {
+  await withEnv(
+    {
+      CANARY_ENDPOINT: "",
+      PUBLIC_CANARY_ENDPOINT: "",
+      PUBLIC_CANARY_ENVIRONMENT: "",
+      VERCEL_ENV: "preview",
+    },
+    async () => {
+      const config = JSON.parse((await request("/api/canary-config")).body);
+
+      assert.equal(config.environment, "production");
+      assert.equal(config.endpoint, "https://canary.mistystep.io");
+    },
+  );
+});
+
 test("DigitalOcean service rejects unrelated routes and write methods", async () => {
   assert.equal((await request("/api/missing")).status, 404);
   assert.equal((await request("/api/canary-config", "POST")).status, 405);

--- a/test/provider-retirement.test.js
+++ b/test/provider-retirement.test.js
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+
+test("active delivery surfaces cannot recreate the retired Vercel project", () => {
+  assert.equal(fs.existsSync(path.join(root, "vercel.json")), false);
+
+  for (const relativePath of [
+    "AGENTS.md",
+    "README.md",
+    "service/canary-contract.js",
+  ]) {
+    const source = fs.readFileSync(path.join(root, relativePath), "utf8");
+    assert.doesNotMatch(source, /\bVercel\b|VERCEL_/);
+  }
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "buildCommand": null,
-  "outputDirectory": ".",
-  "framework": null
-}


### PR DESCRIPTION
## Summary
- remove the retired Vercel manifest and deployment instructions
- make DigitalOcean the sole delivery contract
- ignore retired provider env hints and default Canary to the canonical DigitalOcean endpoint
- add a provider-retirement regression guard

## Verification
- red: provider-default and retirement tests failed before implementation
- green: `./scripts/check.sh` (21 tests)
- `git diff --check`

Adminifi/r90/Habitat/Vulcan/Olympus are explicitly out of scope and untouched.

Agent: codex-orchestrator
Agent-Surface: Codex CLI
Agent-Task: bastion-921