### PR TITLE
chore(ui): adopt Aesthetic v0.25.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.2.1/aesthetic.css" integrity="sha384-C+I3kjlaCOOyWFYUAoAJ0TbBBg4mEkN0bwwHohjSyL5LzkhINcpwgWcJvAQVrQwC" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v0.25.0/aesthetic.css" integrity="sha384-SrhwZwmgRlmOW+wK+CaZcarD/NCTFypxEUIxAaMxAP4vlBX15QTCqxagjT81KBZf" crossorigin="anonymous">
   <script src="/canary-observer.js"></script>
   <style>
     /* site glue: the name row carries the mode toggle */


### PR DESCRIPTION
Updates the pinned jsDelivr Aesthetic stylesheet to v0.25.0 and recomputes SHA-384 SRI from the released bytes.

Proof: ./scripts/check.sh; live CDN SRI hash match.

Powder: aesthetic-011

Agent: orchestrator
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the external visual styling resource to a newer version.
  * No changes to application behavior or page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->